### PR TITLE
Add OpenGraph meta tags

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -7,6 +7,37 @@
 {{ super() }}
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+{% if page and page.meta and page.meta.og_title -%}
+<meta property="og:title" content="{{ page.meta.og_title }}" />
+{% elif page and page.meta and page.meta.title -%}
+<meta property="og:title" content="{{ page.meta.title }}" />
+{% endif -%}
+{% if page and page.meta and page.meta.og_type -%}
+<meta property="og:type" content="{{ page.meta.og_type }}" />
+{% else -%}
+<meta property="og:type" content="website" />
+{% endif -%}
+<meta property="og:url" content="{{ page.canonical_url }}" />
+{% if page and page.meta and page.meta.page_path and page.meta.og_image -%}
+<meta property="og:image:url" content="{{ config.site_url ~ page.meta.page_path ~ page.meta.og_image }}" />
+{% elif page and page.meta and page.meta.og_image -%}
+<meta property="og:image:url" content="{{ page.meta.og_image }}" />
+{% else -%}
+<meta property="og:image:url" content="{{ config.site_url ~ config.theme.favicon }}" />
+{% endif -%}
+{% if page and page.meta and page.meta.og_image_alt -%}
+<meta property="og:image:alt" content="{{ page.meta.og_image_alt }}" />
+{% endif -%}
+{% if page and page.meta and page.meta.og_image_type -%}
+<meta property="og:image:type" content="{{ page.meta.og_image_type}}" />
+{% else -%}
+<meta property="og:image:type" content="image/png" />
+{% endif -%}
+{% if page and page.meta and page.meta.description -%}
+<meta property="og:description" content="{{ page.meta.description }}">
+{% elif config.site_description -%}
+<meta property="og:description" content="{{ config.site_description }}">
+{% endif -%}
 <title> | arXiv e-print repository</title>
 <link rel="stylesheet" href="https://use.typekit.net/kkn2tyz.css">
 <script type="text/x-mathjax-config">

--- a/source/index.md
+++ b/source/index.md
@@ -1,3 +1,8 @@
+---
+og_title: arXiv Accessibility Forum 2024
+og_image: assets/2024-arxiv-forum-logo-full.png
+og_image_alt: The Logo of arXiv with the text Accessibility Forum 2024
+---
 ![Logo for the arXiv forum](../assets/forum-logotype-only.svg){.forum-logotype alt='logo for the arXiv forum' role="presentation"}
 
 # Sign up for the arXiv Accessibility Forum 2024!


### PR DESCRIPTION
This ensures that sharing on SNS sites will display the logo and not the first image found on the page by the scraper.

The og image and tags can be specified in the markdown files header, and this is done for the
index.md file.

The generated index page contains the following tags with these changes:
```
<meta property="og:title" content="arXiv Accessibility Forum 2024" />
<meta property="og:type" content="website" />
<meta property="og:url" content="http://127.0.0.1:8000/index.html" />
<meta property="og:image:url" content="assets/2024-arxiv-forum-logo-full.png" />
<meta property="og:image:alt" content="The Logo of arXiv with the text Accessibility Forum 2024" />
<meta property="og:image:type" content="image/png" />
```